### PR TITLE
event: simplify event porting by leveraging lvgl's event dsc handler

### DIFF
--- a/simulator/main.c
+++ b/simulator/main.c
@@ -283,7 +283,11 @@ int main(int argc, char **argv)
   /*Initialize the HAL (display, input devices, tick) for LVGL*/
   hal_init(480, 480);
 
-  args.root = lv_scr_act();
+  args.root = lv_obj_create(lv_scr_act());
+  lv_obj_set_size(args.root, LV_PCT(100), LV_PCT(100));
+  lv_obj_set_style_outline_width(args.root, 2, 0);
+  lv_obj_set_style_bg_color(args.root, lv_color_hex(0xff00ff), 0);
+  lv_obj_set_style_bg_opa(args.root, LV_OPA_50, 0);
 
   lua_ctx = lua_load_script(LUAVGL_EXAMPLE_DIR "/examples.lua", &args);
 

--- a/src/luavgl.h
+++ b/src/luavgl.h
@@ -48,13 +48,17 @@ typedef struct {
   };
 } luavgl_value_setter_t;
 
+struct event_callback_s {
+  lua_State *L;
+  int ref; /* ref to callback */
+  lv_event_code_t code;
+  lv_event_dsc_t *dsc;
+};
+
 typedef struct luavgl_obj_s {
   lv_obj_t *obj;    /* NULL means obj deleted, but not gc'ed in lua */
   bool lua_created; /* this object is created from lua */
-
-  /* internally used variables */
-  int n_events;
-  struct event_callback_s *events;
+  lv_array_t events;  /* events added from lua, need it to distinguish between lua */
 } luavgl_obj_t;
 
 #define luavgl_obj_newmetatable(L, clz, name, l)                               \

--- a/src/obj.c
+++ b/src/obj.c
@@ -840,8 +840,10 @@ LUALIB_API luavgl_obj_t *luavgl_add_lobj(lua_State *L, lv_obj_t *obj)
   lua_setmetatable(L, -2);
 
   memset(lobj, 0, sizeof(*lobj));
-  luavgl_obj_event_init(lobj);
   lobj->obj = obj;
+
+  /* Init event array to store events added from lua. */
+  lv_array_init(&lobj->events, 0, sizeof(struct event_callback_s *));
   lv_obj_add_event_cb(obj, obj_delete_cb, LV_EVENT_DELETE, L);
 
   /* registry[obj] = lobj */

--- a/src/private.h
+++ b/src/private.h
@@ -14,12 +14,6 @@
 // syslog(LOG_DEBUG, "[luavgl] %s: " format, __FUNCTION__, ##__VA_ARGS__)
 /* clang-format on */
 
-struct event_callback_s {
-  lua_State *L;
-  lv_event_code_t code;
-  int ref; /* ref to callback */
-};         /* variable array if n_callback > 1 */
-
 static void dumpstack(lua_State *L);
 static void dumptable(lua_State *L, int index);
 
@@ -27,7 +21,6 @@ static void dumptable(lua_State *L, int index);
 int luavgl_obj_getmetatable(lua_State *L, const lv_obj_class_t *clz);
 int luavgl_obj_setmetatable(lua_State *L, int idx, const lv_obj_class_t *clz);
 
-static void luavgl_obj_event_init(luavgl_obj_t *lobj);
 static void luavgl_obj_remove_event_all(lua_State *L, luavgl_obj_t *obj);
 
 /* util functions */


### PR DESCRIPTION
Only lua created obj can add event callback, and it makes logic much simpler.

Fix #10

Depends on the dsc returned from add_event, need to wait lvgl merge this change firstly.