### PR TITLE
cmake(simulator): print log to terminal when using cmake with target `run`

### DIFF
--- a/simulator/CMakeLists.txt
+++ b/simulator/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 
 project(simulator)
 
-add_custom_target(run COMMAND simulator)
+add_custom_target(run COMMAND simulator USES_TERMINAL)
 
 file(GLOB_RECURSE WIDGETS ${CMAKE_CURRENT_SOURCE_DIR}/widgets/*.c)
 add_executable(simulator main.c mouse_cursor_icon.c ${WIDGETS})


### PR DESCRIPTION

Now using `cmake --build build -t run` can output log in real time.