### PR TITLE
constants: fix compiler error when widgets are disabled

### DIFF
--- a/src/constants.c
+++ b/src/constants.c
@@ -346,6 +346,7 @@ static void luavgl_dir_init(lua_State* L)
   lua_pushstring(L, "ALL"); lua_pushinteger(L, LV_DIR_ALL); lua_settable(L, -3);
 }
 
+#if LV_USE_KEYBOARD
 static void luavgl_keyboard_mode_init(lua_State* L)
 {
   lua_newtable(L);
@@ -362,6 +363,7 @@ static void luavgl_keyboard_mode_init(lua_State* L)
   lua_pushstring(L, "TEXT_ARABIC"); lua_pushinteger(L, LV_KEYBOARD_MODE_TEXT_ARABIC); lua_settable(L, -3);
 #endif
 }
+#endif
 
 static void luavgl_flex_flow_init(lua_State* L)
 {
@@ -400,12 +402,14 @@ static void luavgl_grid_align_init(lua_State* L)
   lua_pushstring(L, "SPACE_BETWEEN"); lua_pushinteger(L, LV_GRID_ALIGN_SPACE_BETWEEN); lua_settable(L, -3);
 }
 
+#if LV_USE_ROLLER
 static void luavgl_roller_mode_init(lua_State* L)
 {
   lua_newtable(L);
   lua_pushstring(L, "NORMAL"); lua_pushinteger(L, LV_ROLLER_MODE_NORMAL); lua_settable(L, -3);
   lua_pushstring(L, "INFINITE"); lua_pushinteger(L, LV_ROLLER_MODE_INFINITE); lua_settable(L, -3);
 }
+#endif
 
 static void luavgl_key_init(lua_State* L)
 {
@@ -478,16 +482,22 @@ static void luavgl_constants_init(lua_State *L)
   lua_setfield(L, -2, "SCROLLBAR_MODE");
   luavgl_dir_init(L);
   lua_setfield(L, -2, "DIR");
+
+#if LV_USE_KEYBOARD
   luavgl_keyboard_mode_init(L);
   lua_setfield(L, -2, "KEYBOARD_MODE");
+#endif
+
   luavgl_flex_flow_init(L);
   lua_setfield(L, -2, "FLEX_FLOW");
   luavgl_flex_align_init(L);
   lua_setfield(L, -2, "FLEX_ALIGN");
   luavgl_grid_align_init(L);
   lua_setfield(L, -2, "GRID_ALIGN");
+#if LV_USE_ROLLER
   luavgl_roller_mode_init(L);
   lua_setfield(L, -2, "ROLLER_MODE");
+#endif
   luavgl_key_init(L);
   lua_setfield(L, -2, "KEY");
   /* miscellaneous. */
@@ -523,8 +533,10 @@ static void luavgl_constants_init(lua_State *L)
   lua_pushinteger(L, LV_CHART_POINT_NONE);
   lua_setfield(L, -2, "CHART_POINT_NONE");
 
+#if LV_USE_DROPDOWN
   lua_pushinteger(L, LV_DROPDOWN_POS_LAST);
   lua_setfield(L, -2, "DROPDOWN_POS_LAST");
+#endif
 
   lua_pushinteger(L, LV_LABEL_DOT_NUM);
   lua_setfield(L, -2, "LABEL_DOT_NUM");
@@ -536,8 +548,10 @@ static void luavgl_constants_init(lua_State *L)
   lua_pushinteger(L, LV_TABLE_CELL_NONE);
   lua_setfield(L, -2, "TABLE_CELL_NONE");
 
+#if LV_USE_TEXTAREA
   lua_pushinteger(L, LV_TEXTAREA_CURSOR_LAST);
   lua_setfield(L, -2, "TEXTAREA_CURSOR_LAST");
+#endif
 
   lua_pushinteger(L, LV_LAYOUT_FLEX);
   lua_setfield(L, -2, "LAYOUT_FLEX");


### PR DESCRIPTION
Image and Label widgets are essential to lvgl, thus cannot be disabled for now. Other supported widgets can now be disabled separately.