### PR TITLE
Fixed example of flappyBird gameover restarting too fast causing an anomaly and Support for windows compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 /build
 /.vscode
+
+/.xmake
+/.cache
+
 # Prerequisites
 *.d
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@ lua + lvgl = luavgl
 
 **luavgl is currently under development.**
 
-A flappy bird game is ready for showoff. See simulator instructions below which is tested on ubuntu and mac but not windows.
+A flappy bird game is ready for showoff. 
+
+The simulator is built with cmake and has been tested on ubuntu and mac, but not on windows. If you need to build under windows please xmake, which has also been tested under ubuntu.
 
 <p align="center">
   <img src="https://i.ibb.co/nbgYvZW/flappybird.gif" />
@@ -130,6 +132,7 @@ git submodule update --init
 
 #### Dependencies
 
+### cmake
 To run simulator on PC, make sure `lua` header is available, you may need to install below packages.
 
 ```
@@ -138,13 +141,24 @@ sudo apt install libsdl2-dev lua5.3 liblua5.3-dev
 
 Both lua5.3 and lua5.4 are supported. Versions below 5.2 has not been verified but should work through `deps/lua-compat-5.3`.
 
+### xmake
+Compiling with xmake does not require you to install libsdl2 and lua yourself. xmake calls the package manager xrepo, which downloads libsdl2 and lua from github and applies them to the simulator's project.
+
 #### Build and run
+
+##### cmake
 
 ```bash
 cmake -Bbuild -DBUILD_SIMULATOR=ON
 cd build
 make
 make run # run simulator
+```
+
+##### xmake
+```powershell
+xmake b simulator
+xmake r # run simulator
 ```
 ## Custom Widget
 

--- a/examples/flappyBird/flappyBird.lua
+++ b/examples/flappyBird/flappyBird.lua
@@ -596,7 +596,7 @@ local function entry()
             }
         }
 
-        gameoverImg:Anim{
+        local gameoverImgAnim = gameoverImg:Anim{
             run = true,
             start_value = 0,
             end_value = 3600,
@@ -666,6 +666,8 @@ local function entry()
             gameStart()
             playBtn:delete()
             playBtn = nil
+            gameoverImgAnim:delete()
+            gameoverImgAnim = nil
             gameoverImg:delete()
             gameoverImg = nil
             scoreImg:delete()

--- a/simulator/lv_conf.h
+++ b/simulator/lv_conf.h
@@ -607,15 +607,15 @@
 /*File system interfaces for common APIs */
 
 /*API for fopen, fread, etc*/
-#define LV_USE_FS_STDIO 0
+#define LV_USE_FS_STDIO 1
 #if LV_USE_FS_STDIO
-    #define LV_FS_STDIO_LETTER '\0'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
+    #define LV_FS_STDIO_LETTER LV_FS_STDIO_PLAT_LETTER     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
     #define LV_FS_STDIO_PATH ""         /*Set the working directory. File/directory paths will be appended to it.*/
     #define LV_FS_STDIO_CACHE_SIZE 0    /*>0 to cache this number of bytes in lv_fs_read()*/
 #endif
 
 /*API for open, read, etc*/
-#define LV_USE_FS_POSIX 1
+#define LV_USE_FS_POSIX 0
 #if LV_USE_FS_POSIX
     #define LV_FS_POSIX_LETTER '/'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
     #define LV_FS_POSIX_PATH "/"         /*Set the working directory. File/directory paths will be appended to it.*/
@@ -644,7 +644,7 @@
 #endif
 
 /*LODEPNG decoder library*/
-#define LV_USE_LODEPNG 0
+#define LV_USE_LODEPNG 1
 
 /*PNG decoder(libpng) library*/
 #ifndef LV_USE_LIBPNG
@@ -656,14 +656,14 @@
 
 /* JPG + split JPG decoder library.
  * Split JPG is a custom format optimized for embedded systems. */
-#define LV_USE_TJPGD 0
+#define LV_USE_TJPGD 1
 
 /* libjpeg-turbo decoder library.
  * Supports complete JPEG specifications and high-performance JPEG decoding. */
 #define LV_USE_LIBJPEG_TURBO 0
 
 /*GIF decoder library*/
-#define LV_USE_GIF 0
+#define LV_USE_GIF 1
 #if LV_USE_GIF
 /*GIF decoder accelerate*/
 #define LV_GIF_CACHE_DECODE_DATA 0

--- a/simulator/main.c
+++ b/simulator/main.c
@@ -1,8 +1,6 @@
-#include <unistd.h>
 
 #include <stdlib.h>
 #include <stdio.h>
-#include <unistd.h>
 #include <lvgl.h>
 
 #include <lua.h>
@@ -12,6 +10,28 @@
 
 #include <luavgl.h>
 #include "widgets/widgets.h"
+
+#include <string.h>
+
+#if defined(WIN32) || defined(_WIN32) || defined(_WIN32_) || defined(WIN64) || defined(_WIN64) || defined(_WIN64_)
+  #include <direct.h>
+  #define PLATFORM_WINDOWS 1 //Windows平台
+  #include <Windows.h>
+  static void usleep(unsigned long usec)
+  {
+    HANDLE timer;
+    LARGE_INTEGER interval;
+    interval.QuadPart = (10 * usec);
+
+    timer = CreateWaitableTimer(NULL, TRUE, NULL);
+    SetWaitableTimer(timer, &interval, 0, NULL, NULL, 0);
+    WaitForSingleObject(timer, INFINITE);
+    CloseHandle(timer);
+  }
+#elif defined(__linux__)
+  #define PLATFORM_LINUX	 1 //Linux平台
+  #include <unistd.h>
+#endif
 
 typedef struct {
   lua_State *L;

--- a/xmake.lua
+++ b/xmake.lua
@@ -1,0 +1,44 @@
+add_rules("mode.debug", "mode.release")
+
+add_requires("lua 5.4", "libsdl")
+
+add_includedirs("simulator") -- need lv_conf.h and lv_drv_conf.h
+
+target("lvgl")
+    set_kind("static")
+    add_includedirs("deps/lvgl", {public=true})
+    add_packages("libsdl")
+    on_load(function (target)
+        local ProjectLetter = os.projectdir():sub(1, 1)
+        local LV_FS_STDIO_PLAT_LETTER = string.format("LV_FS_STDIO_PLAT_LETTER='%s'", ProjectLetter)
+        target:add("defines", LV_FS_STDIO_PLAT_LETTER)
+        if is_plat("windows") then 
+            target:add("defines", "WIN32")
+        end
+    end)
+    add_files("deps/lvgl/**.c|demos/**.c|examples/**.c|tests/**.c")
+
+target("luavgl")
+    set_kind("static")
+    add_deps("lvgl")
+    add_packages("lua")
+    add_includedirs("src/", {public=true})
+    on_load(function (target) 
+        local ProjectLetter = os.projectdir():sub(1, 1)
+        local LV_FS_STDIO_PLAT_LETTER = string.format("LV_FS_STDIO_PLAT_LETTER='%s'", ProjectLetter)
+        target:add("defines", "LV_CONF_INCLUDE_SIMPLE", "PATH_MAX=1024", LV_FS_STDIO_PLAT_LETTER)
+    end)
+    add_files("src/luavgl.c")
+
+target("simulator")
+    set_kind("binary")
+    add_deps("luavgl")
+    add_packages("lua")
+    on_load(function (target) 
+        local LUAVGL_EXAMPLE_DIR = string.format("%s/examples", string.gsub(os.projectdir(), "\\", "/"))
+        LUAVGL_EXAMPLE_DIR = string.format("LUAVGL_EXAMPLE_DIR=\"%s\"", LUAVGL_EXAMPLE_DIR)
+        target:add("defines", LUAVGL_EXAMPLE_DIR)
+    end)
+    add_defines(string.format("LUAVGL_EXAMPLE_DIR=\"%s/examples\"", string.gsub(os.projectdir(), "\\", "/")), "LV_CONF_INCLUDE_SIMPLE")
+    add_files("simulator/**.c|tt.c")
+    set_rundir("$(scriptdir)")


### PR DESCRIPTION
1.The gameover image plays an animation when the bird dies, and if you click the restart button before the animation finishes, it will cause the animation's callback function to call an empty object.

![669df33d83e15a0c9f414a7b5b44f10](https://github.com/XuNeo/luavgl/assets/92867869/c803e626-96bb-4e70-9796-2b959f99b535)

2.The emulator is supported to be compiled under windows using xmake, and it can be compiled and run under Ubuntu as well.
```bash
xmake b simulator
xmake r simulator
```