### PR TITLE
fix(simulator): fix compile break

### DIFF
--- a/simulator/lv_conf.h
+++ b/simulator/lv_conf.h
@@ -609,6 +609,10 @@
 /*API for fopen, fread, etc*/
 #define LV_USE_FS_STDIO 1
 #if LV_USE_FS_STDIO
+#ifndef LV_FS_STDIO_PLAT_LETTER
+#define LV_FS_STDIO_PLAT_LETTER 'A'
+#endif
+
     #define LV_FS_STDIO_LETTER LV_FS_STDIO_PLAT_LETTER     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
     #define LV_FS_STDIO_PATH ""         /*Set the working directory. File/directory paths will be appended to it.*/
     #define LV_FS_STDIO_CACHE_SIZE 0    /*>0 to cache this number of bytes in lv_fs_read()*/


### PR DESCRIPTION
`LV_FS_STDIO_PLAT_LETTER` is defined in xmake but not cmake.

```
/home/neo/projects/lvgl/luavgl/simulator/lv_conf.h:612:32: error: ‘LV_FS_STDIO_PLAT_LETTER’ undeclared (first use in this function); did you mean ‘LV_FS_STDIO_LETTER’?
  612 |     #define LV_FS_STDIO_LETTER LV_FS_STDIO_PLAT_LETTER     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
      |                                ^~~~~~~~~~~~~~~~~~~~~~~
/home/neo/projects/lvgl/luavgl/deps/lvgl/src/libs/fsdrv/lv_fs_stdio.c:76:24: note: in expansion of macro ‘LV_FS_STDIO_LETTER’
   76 |     fs_drv_p->letter = LV_FS_STDIO_LETTER;
      |                        ^~~~~~~~~~~~~~~~~~
/home/neo/projects/lvgl/luavgl/simulator/lv_conf.h:612:32: note: each undeclared identifier is reported only once for each function it appears in
  612 |     #define LV_FS_STDIO_LETTER LV_FS_STDIO_PLAT_LETTER     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
      |                                ^~~~~~~~~~~~~~~~~~~~~~~
/home/neo/projects/lvgl/luavgl/deps/lvgl/src/libs/fsdrv/lv_fs_stdio.c:76:24: note: in expansion of macro ‘LV_FS_STDIO_LETTER’
   76 |     fs_drv_p->letter = LV_FS_STDIO_LETTER;
```