### PR TITLE
feat(obj): allow to create child obj inside property table

### DIFF
--- a/src/obj.c
+++ b/src/obj.c
@@ -819,6 +819,14 @@ static const luavgl_value_setter_t obj_property_table[] = {
 LUALIB_API int luavgl_obj_set_property_kv(lua_State *L, void *data)
 {
   lv_obj_t *obj = data;
+
+  /* Check for integer key with userdata as value */
+  if (lua_type(L, -2) == LUA_TNUMBER && lua_type(L, -1) == LUA_TUSERDATA) {
+    lv_obj_t *child = luavgl_to_obj(L, -1);
+    lv_obj_set_parent(child, obj);
+    return 0;
+  }
+
   int ret = luavgl_set_property(L, obj, obj_property_table);
 
   if (ret == 0)


### PR DESCRIPTION
This patch allows to create child obj directly in the property table. To make it looks like children are created recursively.

In fact, with this coding style, the children is created firstly and it's stored to property table with integer key. Simply find them out and set parent for them.

```lua
local lvgl = require("lvgl")

local root = lvgl.Object(nil, {
    flex = {
        flex_direction = "row",
        flex_wrap = "wrap",
        justify_content = "center",
        align_items = "center",
        align_content = "center",
    },
    w = 300,
    h = 75,
    align = lvgl.ALIGN.CENTER,
    lvgl.Object(nil, {
        w = 100,
        h = lvgl.PCT(100),
        lvgl.Label(nil, {
            text = string.format("label %d", 1)
        }):center()
    }):clear_flag(lvgl.FLAG.SCROLLABLE),

    lvgl.Object(nil, {
        w = 100,
        h = lvgl.PCT(100),
        lvgl.Label(nil, {
            text = string.format("label %d", 1)
        }):center()
    }):clear_flag(lvgl.FLAG.SCROLLABLE)
})

```