### PR TITLE
feat(obj): allow to omit the nil parent

### DIFF
--- a/examples/analogTime.lua
+++ b/examples/analogTime.lua
@@ -1,4 +1,4 @@
-local analogTime = lvgl.AnalogTime(nil, {
+local analogTime = lvgl.AnalogTime {
     border_width = 0,
     x = lvgl.HOR_RES() // 2,
     y = lvgl.VER_RES() // 2,
@@ -8,6 +8,6 @@ local analogTime = lvgl.AnalogTime(nil, {
         second = SCRIPT_PATH .. "/assets/hand-second.png",
     },
     period = 33,
-})
+}
 
 print("analogTime: ", analogTime)

--- a/examples/dropdown.lua
+++ b/examples/dropdown.lua
@@ -1,5 +1,5 @@
 -- a dropdown on top left
-local dd = lvgl.Dropdown(nil, {
+local dd = lvgl.Dropdown {
     -- note there are two "Orange"
     options = "Apple\nBanana\nOrange\nCherry\nGrape\nRaspberry\nMelon\nOrange\nLemon\nNuts",
     symbol = "\xEF\x81\x94",
@@ -11,7 +11,7 @@ local dd = lvgl.Dropdown(nil, {
         x_ofs = 20,
         y_ofs = 20,
     }
-})
+}
 local list = dd:get("list")
 print("get dropdown list: ", list)
 list:set { text_font = lvgl.BUILTIN_FONT.MONTSERRAT_20 }
@@ -31,7 +31,7 @@ dd:onevent(lvgl.EVENT.VALUE_CHANGED,
 )
 
 -- another dropdown on top left
-local dd = lvgl.Dropdown(nil, {
+local dd = lvgl.Dropdown {
     options = "Apple\nBanana\nOrange\nCherry\nGrape\nRaspberry\nMelon\nOrange\nLemon\nNuts",
     symbol = "\xEF\x81\xB7",
     dir = lvgl.DIR.BOTTOM,
@@ -43,7 +43,7 @@ local dd = lvgl.Dropdown(nil, {
         x_ofs = 0,
         y_ofs = -20,
     }
-})
+}
 
 
 dd:get("list"):set { text_font = lvgl.Font("montserrat", 24) }

--- a/examples/examples.lua
+++ b/examples/examples.lua
@@ -1,4 +1,4 @@
-local container = lvgl.Object(nil, {
+local container = lvgl.Object {
     w = lvgl.HOR_RES(),
     h = lvgl.VER_RES(),
     bg_color = "#888",
@@ -9,7 +9,7 @@ local container = lvgl.Object(nil, {
         flex_direction = "row",
         flex_wrap = "wrap"
     }
-})
+}
 
 print("created container", container)
 

--- a/examples/extension.lua
+++ b/examples/extension.lua
@@ -1,11 +1,11 @@
 -- demo of external widget added to lvgl. See simulator/extension.c
 
-local extension = lvgl.Extension(nil, {
+local extension = lvgl.Extension {
     border_width = 1,
     w = lvgl.PCT(20),
     h = lvgl.PCT(20),
     align = lvgl.ALIGN.CENTER,
-})
+}
 
 extension:onClicked(function ()
     print("clicked")

--- a/examples/flappyBird/flappyBird.lua
+++ b/examples/flappyBird/flappyBird.lua
@@ -44,7 +44,7 @@ local function screenCreate(parent)
             pad_all = 0
         }
     else
-        scr = lvgl.Object(nil, property)
+        scr = lvgl.Object(property)
     end
     scr:clear_flag(lvgl.FLAG.SCROLLABLE)
     scr:clear_flag(lvgl.FLAG.CLICKABLE)

--- a/examples/flexLayout.lua
+++ b/examples/flexLayout.lua
@@ -1,6 +1,6 @@
 local lvgl = require("lvgl")
 
-local root = lvgl.Object(nil, {
+local root = lvgl.Object {
     flex = {
         flex_direction = "row",
         flex_wrap = "wrap",
@@ -11,7 +11,7 @@ local root = lvgl.Object(nil, {
     w = 300,
     h = 75,
     align = lvgl.ALIGN.CENTER
-})
+}
 
 for i = 1, 10 do
     local item = root:Object {

--- a/examples/font.lua
+++ b/examples/font.lua
@@ -1,18 +1,18 @@
-local label1 = lvgl.Label(nil, {
+local label1 = lvgl.Label {
     x = 0, y = 0,
     text_font = lvgl.Font("montserrat", 32, "normal"),
     text = "Hello Font",
     align = lvgl.ALIGN.CENTER
-})
+}
 
 print("label1: ", label1)
 
-lvgl.Label(nil, {
+lvgl.Label {
     -- x= 0, y = 0,
     -- text_font = lvgl.Font("MiSansW medium, montserrat", 24),
     text_font = lvgl.BUILTIN_FONT.MONTSERRAT_22,
     text = "Hello Font2",
-}):align_to({
+}:align_to({
     type = lvgl.ALIGN.OUT_BOTTOM_LEFT,
     base = label1,
 })

--- a/examples/fs.lua
+++ b/examples/fs.lua
@@ -20,19 +20,19 @@ local function fs_example()
     print("header len:", #header, ": ", header)
     print("remaining: ", remaining)
 
-    lvgl.Label(nil, {
+    lvgl.Label {
         x = 0,
         y = 0,
         text_font = lvgl.Font("montserrat", 20, "normal"),
         text = header .. remaining,
         align = lvgl.ALIGN.TOP_LEFT
-    })
+    }
 
-    local list = lvgl.List(nil, {
+    local list = lvgl.List {
         align = lvgl.ALIGN.TOP_RIGHT,
         pad_all = 10,
         text_font = lvgl.BUILTIN_FONT.MONTSERRAT_12
-    })
+    }
     list:add_text("Directory list:")
 
     -- local dir <close>, msg, code = lvgl.fs.open_dir(SCRIPT_PATH .. "/")

--- a/examples/group.lua
+++ b/examples/group.lua
@@ -19,7 +19,7 @@ local function group_example()
             border_color = "#a00",
         })
 
-    local root = lvgl.Object(nil, {
+    local root = lvgl.Object {
             w = lvgl.PCT(100),
             h = lvgl.PCT(100),
             align = lvgl.ALIGN.CENTER,
@@ -28,7 +28,7 @@ local function group_example()
                 flex_direction = "row",
                 flex_wrap = "wrap"
             }
-        })
+        }
 
     root:add_style(style, lvgl.STATE.FOCUSED)
 

--- a/examples/indev.lua
+++ b/examples/indev.lua
@@ -9,12 +9,12 @@ local function indev_example()
     local obj_act = lvgl.indev.get_obj_act()
     print("obj_act: ", obj_act)
 
-    local root = lvgl.Object(nil, {
+    local root = lvgl.Object {
             w = lvgl.PCT(30),
             h = lvgl.PCT(30),
             align = lvgl.ALIGN.CENTER,
             bg_color = "#aaa",
-        })
+        }
 
     root:Object({
         w = 1000,

--- a/examples/keyboard.lua
+++ b/examples/keyboard.lua
@@ -1,10 +1,10 @@
-local root = lvgl.Object(nil, {
+local root = lvgl.Object {
     w = lvgl.HOR_RES(),
     h = lvgl.VER_RES(),
     pad_all = 0,
     bg_color = "#333",
     bg_opa = lvgl.OPA(50),
-})
+}
 root:add_flag(lvgl.FLAG.CLICKABLE)
 
 local ta = root:Textarea {

--- a/examples/pointer.lua
+++ b/examples/pointer.lua
@@ -1,11 +1,11 @@
-local root = lvgl.Object(nil, {
+local root = lvgl.Object {
     w = 0,
     h = 0,
     pad_all = 0,
     align = lvgl.ALIGN.CENTER,
     border_width = 1,
     border_color = "#F00",
-})
+}
 
 local pointer = root:Pointer {
     src = SCRIPT_PATH .. "/assets/second.png",

--- a/examples/protectedcall.lua
+++ b/examples/protectedcall.lua
@@ -21,10 +21,10 @@ local function testCrash6()
     testCrash5()
 end
 
-lvgl.Label(nil, {
+lvgl.Label {
     text = "crash in 1 second.",
     align = lvgl.ALIGN.CENTER
-})
+}
 
 lvgl.Timer {
     period = 1000,

--- a/examples/roller.lua
+++ b/examples/roller.lua
@@ -1,14 +1,13 @@
-local roller = lvgl.Roller(nil, {
+local roller = lvgl.Roller {
     options = {
         options = "January\nFebruary\nMarch\nApril\nMay\nJune\nJuly\nAugust\nSeptember\nOctober\nNovember\nDecember",
         mode = lvgl.ROLLER_MODE.INFINITE,
     },
     visible_cnt = 4,
     align = lvgl.ALIGN.CENTER
-})
+}
 
 print("create roller:", roller)
 roller:onevent(lvgl.EVENT.VALUE_CHANGED, function (obj, code)
     print(obj:get_selected_str())
 end)
-

--- a/examples/tests.lua
+++ b/examples/tests.lua
@@ -1,4 +1,4 @@
-local container = lvgl.Object(nil, {
+local container = lvgl.Object {
     w = lvgl.HOR_RES(),
     h = lvgl.VER_RES(),
     bg_color = "#888",
@@ -9,7 +9,7 @@ local container = lvgl.Object(nil, {
         flex_direction = "row",
         flex_wrap = "wrap"
     }
-})
+}
 
 local function createBtn(parent, name)
     local root = parent:Object {

--- a/src/obj.c
+++ b/src/obj.c
@@ -718,7 +718,7 @@ static const luaL_Reg luavgl_obj_methods[] = {
     {"delete",                   luavgl_obj_delete                  },
     {"clean",                    luavgl_obj_clean                   },
 
- /* misc. functions */
+    /* misc. functions */
     {"parent",                   luavgl_obj_set_get_parent          },
     {"set_parent",               luavgl_obj_set_parent              },
     {"get_parent",               luavgl_obj_get_parent              },
@@ -842,7 +842,8 @@ LUALIB_API int luavgl_obj_create_helper(lua_State *L,
   luavgl_ctx_t *ctx = luavgl_context(L);
   lv_obj_t *parent;
 
-  if (lua_isnoneornil(L, 1)) {
+  int type = lua_type(L, 1);
+  if (type == LUA_TTABLE || type == LUA_TNONE || type == LUA_TNIL) {
     parent = ctx->root;
   } else {
     parent = luavgl_to_obj(L, 1);


### PR DESCRIPTION
Check if the first parameter is table, if so, the parent must be nil and default root is used. This allows us to create object on screen easier.

The change is pretty simple.
```diff
@@ -842,7 +842,7 @@ LUALIB_API int luavgl_obj_create_helper(lua_State *L,
   luavgl_ctx_t *ctx = luavgl_context(L);
   lv_obj_t *parent;

-  if (lua_isnoneornil(L, 1)) {
+  if (lua_type(L, 1) == LUA_TTABLE || lua_isnoneornil(L, 1)) {
     parent = ctx->root;
   } else {
     parent = luavgl_to_obj(L, 1);
```