### PR TITLE
feat(rotable): add metatable support to rotable

### DIFF
--- a/src/rotable.h
+++ b/src/rotable.h
@@ -55,4 +55,12 @@ ROTABLE_EXPORT void rotable_newlib( lua_State* L, void const* reg );
  * `rotable_Reg` array. */
 ROTABLE_EXPORT void rotable_newidx( lua_State* L, void const* reg );
 
+/**
+ * Since the rodata's metatable is used to simulate the table itself,
+ * we use userdata's uservalue to store an optional table as a
+ * metatable. It's used in the __index method when no match is found
+ * in the rotable.
+ */
+ROTABLE_EXPORT void rotable_setmetatable( lua_State* L, int idx);
+
 #endif /* ROTABLE_H_ */


### PR DESCRIPTION
Since rodata's meta table is already used to fake the normal table operation, we use userdata uservalue[2] to store an optional table as meta table. It's further searched when no match found in rodata's __index method.

Fix bug in rotable_newidx.