### PR TITLE
fix(constants.c): end mark for supplementary font table

### DIFF
--- a/src/constants.c
+++ b/src/constants.c
@@ -456,6 +456,9 @@ static const rotable_Reg builtin_font_const_table[] = {
      .ptr = &lv_font_unscii_16,
      },
 #endif
+    {
+     .name = 0,
+     },
 };
 
 static const rotable_Reg scr_load_anim_const_table[] = {


### PR DESCRIPTION
When only the Montserrat 14 font is enabled, sigsegv occurs. It is unclear why it was running normally before.